### PR TITLE
Fix Verbose Command Checking Wrong Permission

### DIFF
--- a/src/main/java/de/photon/aacadditionpro/InternalPermission.java
+++ b/src/main/java/de/photon/aacadditionpro/InternalPermission.java
@@ -5,8 +5,8 @@ import org.bukkit.permissions.Permissible;
 
 public enum InternalPermission
 {
-    AAC_VERBOSE("aac.manage"),
-    AAC_MANAGE("aac.verbose"),
+    AAC_VERBOSE("aac.verbose"),
+    AAC_MANAGE("aac.manage"),
     BYPASS("aacadditionpro.bypass"),
     INFO("aacadditionpro.info"),
     TABLISTREMOVE("aacadditionpro.tablistremove");


### PR DESCRIPTION
Not sure if the verbose command should be updated to check for `aac.debug` since that's aac's new verbose command permission.