### PR TITLE
Fix ModuleType NPE if class is initialized before plugin is started

### DIFF
--- a/src/main/java/de/photon/aacadditionpro/modules/ModuleType.java
+++ b/src/main/java/de/photon/aacadditionpro/modules/ModuleType.java
@@ -47,7 +47,7 @@ public enum ModuleType
     public static final Set<ModuleType> VL_MODULETYPES = EnumSet.noneOf(ModuleType.class);
     private final String configString;
     private final String violationMessage;
-    private final String info;
+    private String info;
 
     @Getter
     @Setter(AccessLevel.PACKAGE)
@@ -62,6 +62,14 @@ public enum ModuleType
     {
         this.configString = configString;
         this.violationMessage = violationMessage;
-        this.info = AACAdditionPro.getInstance().getConfig().getString(configString + ".aacfeatureinfo");
+    }
+
+    public String getInfo()
+    {
+        if (info == null)
+        {
+            info = AACAdditionPro.getInstance().getConfig().getString(configString + ".aacfeatureinfo");
+        }
+        return info;
     }
 }


### PR DESCRIPTION
Some of our plugins need to be loaded before AACAP, but they load its classes, including ModuleType (for example, for EnumSet).
You can say we need to recode our plugins or load them after AACAP, but we can say it is bad practice to be dependent on class loading order in the first place.

If something accesses this class before plugin is started (including your own code by accident), NPE will be thrown (because AACAdditionPro.getInstance() will return null) and class initialization will fail. I fix it by lazy initializing info field.
