### PR TITLE
add detection for changes in unused skin bitmask bit

### DIFF
--- a/src/main/java/de/photon/aacadditionpro/modules/checks/skinblinker/SkinBlinker.java
+++ b/src/main/java/de/photon/aacadditionpro/modules/checks/skinblinker/SkinBlinker.java
@@ -54,9 +54,15 @@ public class SkinBlinker extends ViolationModule
             val user = User.safeGetUserFromPacketEvent(event);
             if (User.isUserInvalid(user, this.getModule())) return;
 
+            val newSkinComponents = event.getPacket().getIntegers().readSafely(1);
+
+            // Unused skin bit used (detection)
+            if ((newSkinComponents & (1 << 7)) != 0) {
+                getManagement().flag(Flag.of(user).setAddedVl(100));
+            }
+
             // Sprinting or sneaking (detection)
             if ((event.getPlayer().isSprinting() || event.getPlayer().isSneaking())) {
-                val newSkinComponents = event.getPacket().getIntegers().readSafely(1);
 
                 // updateSkinComponents returns true if the skin has changed.
                 if (user.updateSkinComponents(newSkinComponents)) getManagement().flag(Flag.of(user).setAddedVl(50));


### PR DESCRIPTION
The 8th bit is not used by vanilla clients ("The most significant bit (bit 7, 0x80) appears to be unused.", https://wiki.vg/Protocol#Client_Settings).

Some Skinblinker-Hacks randomly flips every bit and stop flipping while sprinting and sneaking. A check if the 8th bit is set has no false-positives with a vanilla client and can detect Skinblinker-Hacks even if the player is not sprinting or sneaking. 